### PR TITLE
Proper support of slots in BXL-to-KiCAD

### DIFF
--- a/BXLDecoder.java
+++ b/BXLDecoder.java
@@ -28,6 +28,7 @@
 
 import java.io.*;
 import java.util.Scanner;
+import java.lang.Math;
 
 public class BXLDecoder {
 
@@ -75,19 +76,15 @@ public class BXLDecoder {
     String SymbolDefs[] = new String[20];
 
     // some variables for kicad eeschema symbol export
-    String kicadHeader = "EESchema-LIBRARY Version 2.3\n#\n# converted by BXL2text https://github.com/erichVK5/BXL2text";
-    //String kicadDefs = "";
-    //String kicadDrawn = "\nDRAW";
-    //String kicadFPList = "\n$FPLIST";
-    String kicadDefs[] = new String[20];
+    String kicadFPList = "";
     String kicadDrawn[] = new String[20];
-    String kicadFPList[] = new String[20];
-    int dfIndex = -1;
+    int dfIndex = 0;
+    kicadDrawn[dfIndex] = "";
 
     String newSymbol = "";
     String symAttributes = "";
     PadStackList padStacks = new PadStackList();
-    PinList pins[] = new PinList[20]; // slots = 0
+    PinList pins = new PinList(20); // slots = 20
 
     long xOffset = 0;
     long yOffset = 0;
@@ -127,6 +124,7 @@ public class BXLDecoder {
 
 
         }
+
         try {
           File newFP = new File(FPName + ".fp");
           PrintWriter FPOutput = new PrintWriter(newFP);
@@ -143,25 +141,15 @@ public class BXLDecoder {
           System.out.println(e);
         }
         newElement = ""; // reset the variable
+
       } else if (currentLine.startsWith("Symbol ")) {
         String [] tokens = currentLine.split(" ");
 	dfIndex++;
 
         SymbolName[dfIndex] = tokens[1].replaceAll("[\"]","");
 
-        // build a kicad symbol header DEF section here
-	kicadDefs[dfIndex] = 
-                         "\n# " + SymbolName[dfIndex] + "\n#\n"
-                       + "DEF " + SymbolName[dfIndex] + " U 0 40 Y Y 1 F N\n"
-                       + "F0 \"U\" 0 -150 50 H V C CNN\n"
-                       + "F1 \"" + SymbolName[dfIndex] + "\" 0 150 50 H V C CNN";
-
-        //        PinList pins = new PinList(0); // slots = 0
-        // pins = new PinList(0); // slots = 0
-
-        kicadDrawn[dfIndex] = "\nDRAW";
-        kicadFPList[dfIndex] = "\n$FPLIST";
-        pins[dfIndex] = new PinList(0); // slots = 0
+        // Construct string for storing kicad drawn items
+        kicadDrawn[dfIndex] = "";
 
         while (textBXL.hasNext() &&
                !currentLine.startsWith("EndSymbol")) {
@@ -174,7 +162,7 @@ public class BXLDecoder {
                 textBXL.nextLine().trim(); // we combine the 3 lines
             latestPin.populateBXLElement(currentLine);
             latestPin.setSlot(dfIndex);
-            pins[dfIndex].addPin(latestPin);
+            pins.addPin(latestPin);
           } else if (currentLine.startsWith("Line")) {
             SymbolPolyline symbolLine = new SymbolPolyline();
             symbolLine.populateBXLElement(currentLine);
@@ -231,56 +219,69 @@ public class BXLDecoder {
             String FPAttr = "footprint=" + currentLine;
             symAttributes = symAttributes
                   + SymbolText.BXLAttributeString(0,0, FPAttr);
-            kicadFPList[dfIndex] = kicadFPList[dfIndex] + "\n " + currentLine;
+            kicadFPList = kicadFPList + "\n " + currentLine;
           } else if (currentLine.startsWith("AlternatePattern")) {
             currentLine = currentLine.replaceAll(" ", "");
             currentLine = currentLine.split("\"")[1];
             String AltFPAttr = "alt-footprint=" + currentLine;
             symAttributes = symAttributes
                   + SymbolText.BXLAttributeString(0,0, AltFPAttr);
-            kicadFPList[dfIndex] = kicadFPList[dfIndex] + "\n " + currentLine;
+            kicadFPList = kicadFPList + "\n " + currentLine;
           } else if (currentLine.startsWith("CompPin ")) {
-            pins[dfIndex].setBXLPinType(currentLine);
+            pins.setBXLPinType(currentLine);
           }
         }
-        try {
-//          File newSym = new File(symbolName + ".sym");
-//          PrintWriter symOutput = new PrintWriter(newSym);
-//          symOutput.println(newSymbol   // we now add pins to the
-//                            + pins.toString(0,0) // the header, and then
-//                            + symAttributes); // the final attributes
 
-          for (int i=0; i < kicadDefs.length; i++) {
-          if (kicadDefs[i] == null) break;
+        try {
+          int usedSlots = Math.max(pins.usedSlots(), 2);
+          // Skip slot=0 as it contains items common to all other slots
+          for (int i=1; i < usedSlots; i++) {
               File newSym = new File(SymbolName[i] + ".sym");
               PrintWriter symOutput = new PrintWriter(newSym);
               symOutput.println(SymbolDefs[i] // we now add pins to the
-                            + pins[i].toString(i,0,0) // the header, and then
+                            + pins.toString(i,0,0) // the header, and then
                             + symAttributes); // the final attributes
               symOutput.close();
               System.out.println(SymbolName[i] + ".sym");
           }
+        } catch(Exception e) {
+          System.out.println("There was an error saving: "
+                             + symbolName + ".sym");
+          System.out.println(e);
+        }
+        symAttributes = "";
 
-//          symOutput.close();
-//          System.out.println(symbolName + ".sym");
-
-          // KiCad symbol export
-//          String kicad = kicadHeader
-//                            + kicadDefs
-//                            + kicadFPList + "\n$ENDFPLIST" // name says it all
-//                            + kicadDrawn  // drawn elements here
-//                            + pins.toKicad(0,0) // we now add pins
-//                            + "\nENDDRAW\nENDDEF";
-
-          String kicad = kicadHeader;
-          for (int i=0; i < kicadDefs.length; i++) {
-          if (kicadDefs[i] == null) break;
-              kicad += kicadDefs[i]
-                            + kicadFPList[i] + "\n$ENDFPLIST" // name says it all
-                            + kicadDrawn[i]  // drawn elements here
-                            + pins[i].toKicad(i,0,0) // we now add pins
-                            + "\nENDDRAW\nENDDEF";
+        try {
+          String kicad = "";
+          // First SymbolName should be without slot index, so it's best to
+          // use it for the kiCAD format which doesn't have separate symbols
+          // for each slot/unit; all units are within one DRAW section.
+          String kicadSymName = "";
+          // Count only used slots
+          int usedSlots = pins.usedSlots();
+          String unitsLocked = (usedSlots > 2) ? "L" : "F";
+          for (int i=0; i < usedSlots; i++) {
+              if ((SymbolName[i] == null) || SymbolName[i].isEmpty())
+                  continue;
+              if (kicadSymName.isEmpty() || kicadSymName.compareTo(SymbolName[i]) > 0)
+                  kicadSymName = SymbolName[i];
           }
+          kicad += "EESchema-LIBRARY Version 2.3"
+                 // start with a comment
+                 + "\n#\n# converted by BXL2text https://github.com/erichVK5/BXL2text"
+                 + "\n# " + kicadSymName + "\n#\n";
+                 // build a kicad symbol header DEF section
+                 // DEF name reference unused text_offset draw_pinnumber draw_pinname unit_count units_locked option_flag
+          kicad += "DEF " + kicadSymName + " U 0 40 Y Y " + (usedSlots - 1) + " " + unitsLocked + " N\n"
+                 + "F0 \"U\" 0 -150 50 H V C CNN\n"
+                 + "F1 \"" + kicadSymName + "\" 0 150 50 H V C CNN";
+          kicad += "\n$FPLIST" + kicadFPList + "\n$ENDFPLIST" // list of matching footprints
+                 + "\nDRAW";
+          for (int i=0; i < usedSlots; i++) {
+              kicad += kicadDrawn[i];  // drawn elements here
+              kicad += pins.toKicad(i,0,0); // we now add pins
+          }
+          kicad += "\nENDDRAW\nENDDEF";
 
           File newKicad = new File(symbolName + ".lib");
           PrintWriter symOutput = new PrintWriter(newKicad);
@@ -290,10 +291,9 @@ public class BXLDecoder {
 
         } catch(Exception e) {
           System.out.println("There was an error saving: "
-                             + symbolName + ".sym"); 
+                             + symbolName + ".lib");
           System.out.println(e);
         }
-        symAttributes = "";
       }
     }
   }      

--- a/BXLDecoder.java
+++ b/BXLDecoder.java
@@ -255,7 +255,7 @@ public class BXLDecoder {
               File newSym = new File(SymbolName[i] + ".sym");
               PrintWriter symOutput = new PrintWriter(newSym);
               symOutput.println(SymbolDefs[i] // we now add pins to the
-                            + pins[i].toString(0,0) // the header, and then
+                            + pins[i].toString(i,0,0) // the header, and then
                             + symAttributes); // the final attributes
               symOutput.close();
               System.out.println(SymbolName[i] + ".sym");
@@ -278,7 +278,7 @@ public class BXLDecoder {
               kicad += kicadDefs[i]
                             + kicadFPList[i] + "\n$ENDFPLIST" // name says it all
                             + kicadDrawn[i]  // drawn elements here
-                            + pins[i].toKicad(0,0) // we now add pins
+                            + pins[i].toKicad(i,0,0) // we now add pins
                             + "\nENDDRAW\nENDDEF";
           }
 

--- a/BXLDecoder.java
+++ b/BXLDecoder.java
@@ -173,10 +173,12 @@ public class BXLDecoder {
                 textBXL.nextLine().trim() + " " +
                 textBXL.nextLine().trim(); // we combine the 3 lines
             latestPin.populateBXLElement(currentLine);
+            latestPin.setSlot(dfIndex);
             pins[dfIndex].addPin(latestPin);
           } else if (currentLine.startsWith("Line")) {
             SymbolPolyline symbolLine = new SymbolPolyline();
             symbolLine.populateBXLElement(currentLine);
+            symbolLine.setSlot(dfIndex);
             SymbolDefs[dfIndex] = SymbolDefs[dfIndex]
                 + "\n" + symbolLine.toString(0,0);
             kicadDrawn[dfIndex] = kicadDrawn[dfIndex]

--- a/PinList.java
+++ b/PinList.java
@@ -38,7 +38,6 @@ public class PinList {
   SymbolPin[][] slotArrays;
   int[] pinCounts;
   int numSlots = 1;
-  int kicadSlots = 0;
   int pinsPerSlot = 10; //default value, but resizes automatically if needed
   int totalPinCount = 0;
   int maxPinNumber = 0;
@@ -64,7 +63,7 @@ public class PinList {
   }
 
   public PinList(int slotCount) {
-    kicadSlots = slotCount;
+    // We will store common symbols in slot[0], so we need one more
     numSlots = slotCount + 1;
     //    System.out.println("New pinlist created with " + numSlots + " slots");
     slotArrays = new SymbolPin[numSlots][pinsPerSlot];
@@ -299,7 +298,7 @@ public class PinList {
       }
     }
 
-    PinList gridAlignedPins = new PinList(kicadSlots);
+    PinList gridAlignedPins = new PinList(numSlots-1);
     //    gridAlignedPins.resetXYExtents();
         // now need to recalculate bounds while
         // adding transmogrified pins to new pin list
@@ -580,11 +579,11 @@ public class PinList {
 
   private String slotSummary(long xOffset, long yOffset, long ROffset) {
     String summary = "";
-    if (kicadSlots < 2) {
+    if (numSlots < 3) {
       summary = SymbolText.attributeString(ROffset + xOffset, yOffset, "numslots=0");
     } else { // this is a multi-slot device
       // we summarise the number of slots
-      summary = SymbolText.attributeString(ROffset + xOffset, yOffset, "numslots=" + kicadSlots);
+      summary = SymbolText.attributeString(ROffset + xOffset, yOffset, "numslots=" + (numSlots - 1));
       // we explain which slot is implemented in the symbol
       summary = summary + SymbolText.attributeString(ROffset + xOffset, yOffset, "slot=1");
       // then we generate some slotdefs
@@ -592,7 +591,7 @@ public class PinList {
         summary = summary + SymbolText.attributeString(ROffset + xOffset, yOffset, "slotdef=" + index + ":");
         for (int pin = 0 ; pin < pinCounts[index]; pin ++) {
           summary = summary + slotArrays[index][pin].pinNumber;
-          if (pin < (pinCounts[index] -1)) {
+          if (pin < (pinCounts[index] - 1)) {
             summary = summary + ",";
           }
         }

--- a/PinList.java
+++ b/PinList.java
@@ -610,7 +610,7 @@ public class PinList {
   }
   
   public long minX() { // this returns pin minX
-    minX = slotArrays[0][0].localMinXCoord();
+    minX = Long.MAX_VALUE;
     for (int index = 0; index < numSlots; index++) {
       for (int pin = 0 ; pin < pinCounts[index]; pin ++) {
         if (minX > slotArrays[index][pin].localMinXCoord()) {
@@ -622,7 +622,7 @@ public class PinList {
   }
 
   public long minY() { // this returns pin minY
-    minY = slotArrays[0][0].localMinYCoord();
+    minY = Long.MAX_VALUE;
     for (int index = 0; index < numSlots; index++) {
       for (int pin = 0 ; pin < pinCounts[index]; pin ++) {
         if (minY > slotArrays[index][pin].localMinYCoord()) {
@@ -634,7 +634,7 @@ public class PinList {
   }
 
   public long maxX() { // this returns pin maxX
-   maxX = slotArrays[0][0].localMaxXCoord();
+    maxX = Long.MIN_VALUE;
     for (int index = 0; index < numSlots; index++) {
       for (int pin = 0 ; pin < pinCounts[index]; pin ++) {
         if (maxX < slotArrays[index][pin].localMaxXCoord()) {
@@ -643,10 +643,10 @@ public class PinList {
       }
     }
     return maxX;
-  } 
+  }
 
   public long maxY() { // this returns pin maxY
-   maxY = slotArrays[0][0].localMaxYCoord();
+    maxY = Long.MIN_VALUE;
     for (int index = 0; index < numSlots; index++) {
       for (int pin = 0 ; pin < pinCounts[index]; pin ++) {
         if (maxY < slotArrays[index][pin].localMaxYCoord()) {

--- a/SymbolElement.java
+++ b/SymbolElement.java
@@ -36,7 +36,10 @@ public class SymbolElement
   static long minX = 0;
   static long maxY = 0;
   static long minY = 0;
-  
+
+   /** Slot/unit/part to which the element belongs. */
+  int slot = 0;
+
   public void SymbolPolyline()
   {
     output = "#Hmm, the no arg symbol polygon constructor didn't do much";
@@ -76,6 +79,26 @@ public class SymbolElement
 
   public long localMinYCoord() {
     return 0;
+  }
+
+  /** Returns the value of unit/slot/part/symbol index.
+   *
+   * Unit (in kiCAD) is equivalent to slot (in gschem). When component is
+   * complex, sometimes it can be divided into multiple graphics symbols,
+   * which on PCB layout all translate to a single footprint.
+   */
+  public int slot() {
+    return slot;
+  }
+
+  /** Sets the value of unit/slot/part/symbol index.
+   *
+   * In most file formats there is no slot defined in every line.
+   * But in some formats (ie. kiCAD) this is required; hence we need to
+   * inform the element which unit it belongs to.
+   */
+  public void setSlot(int nslot) {
+    this.slot = nslot;
   }
 
   public String toString(long xOffset, long yOffset) {

--- a/SymbolPin.java
+++ b/SymbolPin.java
@@ -82,7 +82,6 @@ public class SymbolPin extends SymbolElement
   String pinDirection = "0"; // default non-sensical value
   int pinType = 0; // 0 = normal, and 1 = bus/unused
   int activeEnd = 0; // 1 = first end, 0 = second end
-  int kicadUnit = 0; // equivalent to gschem "slot"
 
   String kicadEType = "P"; // kicad equivalent to gschem pintype=
   String pinEType = "pas"; //default setting
@@ -132,7 +131,7 @@ public class SymbolPin extends SymbolElement
     copyOf.pinLength = this.pinLength;
     copyOf.pinDirection = this.pinDirection;
     copyOf.pinEType = this.pinEType;
-    copyOf.kicadUnit = this.kicadUnit;
+    copyOf.slot = this.slot;
     copyOf.organiseLabelAndPinCoords();
     return copyOf;
   }
@@ -170,7 +169,7 @@ public class SymbolPin extends SymbolElement
     super.updateYdimensions(yCoord1);
     organiseLabelAndPinCoords();
 
-    kicadUnit = 0; // assume only one slot
+    slot = 0; // assume only one slot
     pinEType = "pas"; // default for now, may be able to fix
     // by parsing the pin description in the IBIS file. Meh.
 
@@ -202,7 +201,7 @@ public class SymbolPin extends SymbolElement
     super.updateYdimensions(yCoord1);
     organiseLabelAndPinCoords();
 
-    kicadUnit = 0; // assume only one slot
+    slot = 0; // assume only one slot
     pinEType = "pas"; // default for now, may be able to fix...
 
   }
@@ -224,7 +223,7 @@ public class SymbolPin extends SymbolElement
     super.updateYdimensions(yCoord1);
     organiseLabelAndPinCoords();
 
-    kicadUnit = 0; // assume only one slot
+    slot = 0; // assume only one slot
     pinEType = "pas"; // default for now, may be able to fix...
 
   }
@@ -337,7 +336,7 @@ public class SymbolPin extends SymbolElement
     super.updateYdimensions(yCoord1);
     organiseLabelAndPinCoords();
 
-    kicadUnit = 0; // assume only one slot
+    slot = 0; // assume only one slot
     pinEType = EagleEType; // Eagle used pretty much the same notation
     // except for "nc" = not connected
   }
@@ -385,7 +384,7 @@ public class SymbolPin extends SymbolElement
     super.updateYdimensions(yCoord1);
     organiseLabelAndPinCoords();
 
-    kicadUnit = 0; // assume only one slot
+    slot = 0; // assume only one slot
     pinEType = "pas"; // default for now, may be able to fix
 
   }
@@ -409,8 +408,8 @@ public class SymbolPin extends SymbolElement
 
     organiseLabelAndPinCoords();
 
-    // the kicadUnit is equivalent to the slot in gschem... useful
-    kicadUnit = Integer.parseInt(tokens[9]);
+    // the kicad Unit is equivalent to the slot in gschem... useful
+    slot = Integer.parseInt(tokens[9]);
 
     kicadEType = tokens[11]; // the electrical type of the pin
     setPinType(kicadEType); // now set it
@@ -655,14 +654,10 @@ public class SymbolPin extends SymbolElement
             + length + " " // length of pin
             + direction + " " // R for Right, L for left, U for Up, D for Down
             + (50) + " " + (50) + " " // Text sizes for the pin name and pin number
-            + kicadUnit + " " // unit no. in case of multiple units
+            + slot + " " // unit no. in case of multiple units
             + (0) + " " //  In case of variations in shape for units, each variation has a number. 0 indicates no variations. For example, an inverter may have two variations - one with the bubble on the input and one on the output.
             + kicadEType.charAt(0) // Elec. Type of pin (I=Input, O=Output, B=Bidi, T=tristate,P=Passive, U=Unspecified, W=Power In, w=Power Out, C=Open Collector, E=Open Emitter, N=Not Connected)
             ); // end - because Graphic Style of pin is optional
-  }
-
-  public int slot() {
-    return kicadUnit; // kicadUnit is equivalent to slot in gschem
   }
 
   public char pinDirection() {

--- a/SymbolPolyline.java
+++ b/SymbolPolyline.java
@@ -48,6 +48,8 @@ public class SymbolPolyline extends SymbolElement
 
   String polylineDescriptor = "";  
   String output = "";
+
+  boolean separateLines = false;
   
   int vertices = 0;
   long xCoords[] = new long[30];
@@ -143,10 +145,24 @@ public class SymbolPolyline extends SymbolElement
   }
 
   public String toKicad(long xOffset, long yOffset) {
+    if (separateLines)
+         return toKicadLines(xOffset, yOffset);
+    else
+         return toKicadPolys(xOffset, yOffset);
+  }
+
+  /** Prepare a string with mulyiple separate lines made of the polygon data
+   * in KiCAD format.
+   */
+  public String toKicadLines(long xOffset, long yOffset) {
     String kicadOutput = "";
     for (int index = 0; index < (vertices - 1); index++) {
       kicadOutput = (kicadOutput
-                + "P " + vertices + " 0 1 0 " // part dmg pen
+                + "P "
+                + vertices + " "
+                + slot + " " // part/unit
+                + 1 + " " // dmg/convert
+                + 0 + " " // pen/thickness
                 + (xCoords[index] + xOffset) + " "
                 + (yCoords[index] + yOffset) + " "
                 + (xCoords[index+1] + xOffset) + " "
@@ -157,6 +173,29 @@ public class SymbolPolyline extends SymbolElement
       }
     }
     return kicadOutput;
-  }  
+  }
+
+  /** Prepare a string with polygon data in KiCAD format.
+   */
+  public String toKicadPolys(long xOffset, long yOffset) {
+    String kicadOutput = "";
+    // P point_count unit convert thickness (posx posy)* fill
+    kicadOutput = (kicadOutput
+                + "P "
+                + vertices + " "
+                + slot + " " // part/unit
+                + 1 + " " // dmg/convert
+                + 0 + " " // pen/thickness
+                );
+    for (int index = 0; index < vertices; index++) {
+      kicadOutput = (kicadOutput
+                  + (xCoords[index] + xOffset) + " "
+                  + (yCoords[index] + yOffset) + " "
+                  );
+    }
+    kicadOutput = (kicadOutput
+                + "N"); // not filled
+    return kicadOutput;
+  }
 
 }


### PR DESCRIPTION
These patches provide even better support of BXL files published by Texas Instruments.

After naming over 400 pins in a BGA device, I decided to update the conversion to convey proper BGA pin numbers, not just incrementing indexes. But while at it, I also noticed KiCAD has slots support, though they're named 'units' there. The converter even had some base elements of multi-slot symbols support, so I built on that.

Please check whether SYM files are generated correctly after this update - I don't even know what opens these. Since I changed the way pins are stored (from array to single object), it could have affected SYM format.